### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,14 +28,14 @@
   },
   "homepage": "https://github.com/emertechie/express-local-auth",
   "dependencies": {
-    "express": "~4.4.3",
-    "lodash": "~2.4.1",
-    "express-validator": "~2.3.0",
-    "node-uuid": "~1.4.1",
     "async": "~0.9.0",
-    "passport-local": "~1.0.0",
+    "bcrypt": "~0.8.0",
+    "express": "~4.4.3",
+    "express-validator": "~2.3.0",
+    "lodash": "~2.4.1",
     "passport": "~0.2.0",
-    "bcrypt": "~0.8.0"
+    "passport-local": "~1.0.0",
+    "uuid": "^3.0.0"
   },
   "devDependencies": {
     "body-parser": "~1.4.3",

--- a/src/forgotPassword.js
+++ b/src/forgotPassword.js
@@ -1,5 +1,5 @@
 var _ = require('lodash'),
-    uuid = require('node-uuid'),
+    uuid = require('uuid'),
     async = require('async'),
     utils = require('./utils');
 

--- a/src/registration.js
+++ b/src/registration.js
@@ -1,5 +1,5 @@
 var _ = require('lodash'),
-    uuid = require('node-uuid'),
+    uuid = require('uuid'),
     utils = require('./utils');
 
 module.exports = function(sharedServices, authService, options) {


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.